### PR TITLE
Enable dual dataset plotting

### DIFF
--- a/TTC_data_analysis/plotTTCData_fit.m
+++ b/TTC_data_analysis/plotTTCData_fit.m
@@ -1,35 +1,57 @@
 function runInteractiveTireCurves
-% runInteractiveTireCurves  Interactive TTC visualization with real-time filters and separate-window fit
+% runInteractiveTireCurves  Interactive TTC visualization with real-time filters
+% and separate-window fit. This version allows two MAT files to be loaded and
+% visualised simultaneously.
+
 clear; clc;
 
-% --- 1) Select TTC run file ---
-[filename, pathname] = uigetfile('*.mat','Select a TTC run .mat file');
-if isequal(filename,0)
-    disp('Selection cancelled.'); return;
+offset2 = 63;  % vertical offset applied to second dataset
+
+% --- 1) Select TTC run files ---
+[files, pathname] = uigetfile('*.mat','Select two TTC run .mat files', ...
+    'MultiSelect','on');
+if isequal(files,0)
+    disp('Selection cancelled.');
+    return;
 end
-fullpath = fullfile(pathname, filename);
+if ischar(files)
+    files = {files};
+end
+if numel(files) < 2
+    error('Please select two MAT files.');
+end
+fullpaths = fullfile(pathname, files);
 
 % --- 2) Load data ---
-data = load(fullpath,'AMBTMP', 'ET', 'MX', 'N', 'NFX', 'NFY', 'RE', 'RL', 'RST', 'RUN', 'SA', 'SL', 'SR','FZ','FX','FY','MZ','P','IA','TSTI','TSTC','TSTO', 'V');
-TSTmed = (data.TSTI + data.TSTC + data.TSTO)/3;
+data1 = load(fullpaths{1}, 'AMBTMP', 'ET', 'MX', 'N', 'NFX', 'NFY', 'RE', 'RL', ...
+    'RST', 'RUN', 'SA', 'SL', 'SR','FZ','FX','FY','MZ','P','IA','TSTI','TSTC', ...
+    'TSTO', 'V');
+data2 = load(fullpaths{2}, 'AMBTMP', 'ET', 'MX', 'N', 'NFX', 'NFY', 'RE', 'RL', ...
+    'RST', 'RUN', 'SA', 'SL', 'SR','FZ','FX','FY','MZ','P','IA','TSTI','TSTC', ...
+    'TSTO', 'V');
+%TSTmed1 = (data1.TSTI + data1.TSTC + data1.TSTO)/3;
+%TSTmed2 = (data2.TSTI + data2.TSTC + data2.TSTO)/3;
+
+datasetNames = files;  % used for legend
 
 % --- 3) Define axis options and ranges ---
-% Dynamically get all data fields except the 'range' variables:
-allFields = fieldnames(data);
+% Dynamically get all data fields except the 'range' variables (assuming same
+% fields in both MAT files)
+allFields = fieldnames(data1);
 exclude   = {'FZ','P','IA'};                                 % Fields to exclude from X axis options
 xOptions  = setdiff(allFields, exclude, 'stable');         % Available X axis variables
 xLabels   = xOptions;    % Labels for X popup (modify for prettier text if desired)
 
 % Y axis options, dynamically get all data fields except the 'range' variables:
-allFields = fieldnames(data);
+allFields = fieldnames(data1);
 exclude   = {'FZ','P','IA'};
 yOptions  = setdiff(allFields, exclude, 'stable');
 yLabels   = yOptions;
 
-% Preserve original ranges for FZ, P, IA sliders
-range.FZ  = [min(data.FZ), max(data.FZ)];
-range.P   = [min(data.P),  max(data.P)];
-range.IA  = [min(data.IA), max(data.IA)];
+% Preserve original ranges for FZ, P, IA sliders using both datasets
+range.FZ  = [min([data1.FZ; data2.FZ]), max([data1.FZ; data2.FZ])];
+range.P   = [min([data1.P;  data2.P ]), max([data1.P;  data2.P ])];
+range.IA  = [min([data1.IA; data2.IA]), max([data1.IA; data2.IA])];
 
 % --- 4) Create main GUI ---
 hFig = figure('Name','Interactive Tire Curves','NumberTitle','off','Position',[200 200 800 600]);
@@ -81,33 +103,75 @@ function updatePlot(~,~)
     xVar = xOptions{selX}; xLabel = xLabels{selX};
     yVar = yOptions{selY}; yLabel = yLabels{selY};
     if strcmp(xVar,'FZ')
-        set(hFZmin,'Enable','off'); set(hFZmax,'Enable','off'); fzMin=range.FZ(1); fzMax=range.FZ(2);
+        set(hFZmin,'Enable','off'); set(hFZmax,'Enable','off');
+        fzMin = range.FZ(1); fzMax = range.FZ(2);
     else
-        set(hFZmin,'Enable','on'); set(hFZmax,'Enable','on'); fzMin=get(hFZmin,'Value'); fzMax=get(hFZmax,'Value');
+        set(hFZmin,'Enable','on'); set(hFZmax,'Enable','on');
+        fzMin = get(hFZmin,'Value'); fzMax = get(hFZmax,'Value');
     end
-    pMin=get(hPmin,'Value'); pMax=get(hPmax,'Value'); iaMin=get(hImin,'Value'); iaMax=get(hImax,'Value');
+    pMin  = get(hPmin,'Value'); pMax = get(hPmax,'Value');
+    iaMin = get(hImin,'Value'); iaMax = get(hImax,'Value');
     if pMin>pMax, tmp=pMin; pMin=pMax; pMax=tmp; end
     if iaMin>iaMax, tmp=iaMin; iaMin=iaMax; iaMax=tmp; end
-    X = data.(xVar); Y = data.(yVar);
-    mask = (data.FZ>=fzMin & data.FZ<=fzMax) & (data.P>=pMin & data.P<=pMax) & (data.IA>=iaMin & data.IA<=iaMax);
-    xF = X(mask); yF = Y(mask); Tcol = TSTmed(mask);
-    [xF, idx] = sort(xF); yF = yF(idx); Tcol = Tcol(idx);
+
+    % Dataset 1
+    X1 = data1.(xVar); Y1 = data1.(yVar);
+    mask1 = (data1.FZ>=fzMin & data1.FZ<=fzMax) & (data1.P>=pMin & data1.P<=pMax) & ...
+            (data1.IA>=iaMin & data1.IA<=iaMax);
+    xF1 = X1(mask1); yF1 = Y1(mask1); %T1 = TSTmed1(mask1);
+    [xF1, idx] = sort(xF1); yF1 = yF1(idx); %T1 = T1(idx);
+
+    % Dataset 2
+    X2 = data2.(xVar); Y2 = data2.(yVar);
+    mask2 = (data2.FZ>=fzMin & data2.FZ<=fzMax) & (data2.P>=pMin & data2.P<=pMax) & ...
+            (data2.IA>=iaMin & data2.IA<=iaMax);
+    xF2 = X2(mask2);
+    yF2 = Y2(mask2) - offset2; % apply vertical offset
+    [xF2, idx] = sort(xF2); yF2 = yF2(idx); %T2 = T2(idx);
+
     cla(hAx);
-    scatter(hAx, xF, yF, 36, Tcol, 'filled'); colormap(hAx,'jet'); colorbar(hAx);
-    xlabel(hAx, xLabel,'Interpreter','none'); ylabel(hAx, yLabel,'Interpreter','none');
-    title(hAx, sprintf('%s vs %s',yLabel,xLabel),'Interpreter','none'); grid(hAx,'on');
+    hold(hAx,'on');
+    scatter(hAx, xF1, yF1, 36, 'filled','Marker','o');
+    scatter(hAx, xF2, yF2, 36, 'filled','Marker','^');
+    %colormap(hAx,'jet'); colorbar(hAx);
+    %caxis(hAx,[min([T1;T2]) max([T1;T2])]);
+    hold(hAx,'off');
+    xlabel(hAx, xLabel,'Interpreter','none');
+    ylabel(hAx, yLabel,'Interpreter','none');
+    title(hAx, sprintf('%s vs %s',yLabel,xLabel),'Interpreter','none');
+    grid(hAx,'on');
+    legend(hAx,datasetNames,'Interpreter','none','Location','best');
 end
 
 % --- Nested function: doFit ---
 function doFit(~,~)
     selX = get(hPopupX,'Value'); selY = get(hPopupY,'Value');
     xVar = xOptions{selX}; yVar = yOptions{selY};
-    X = data.(xVar); Y = data.(yVar);
-    fzMin = get(hFZmin,'Value'); fzMax = get(hFZmax,'Value');
+    if strcmp(xVar,'FZ')
+        fzMin = range.FZ(1); fzMax = range.FZ(2);
+    else
+        fzMin = get(hFZmin,'Value'); fzMax = get(hFZmax,'Value');
+    end
     pMin  = get(hPmin,'Value');  pMax  = get(hPmax,'Value');
     iaMin = get(hImin,'Value');  iaMax = get(hImax,'Value');
-    mask   = (data.FZ>=fzMin & data.FZ<=fzMax) & (data.P>=pMin & data.P<=pMax) & (data.IA>=iaMin & data.IA<=iaMax);
-    xF    = X(mask); yF    = Y(mask);
+
+    % Dataset 1
+    X1 = data1.(xVar); Y1 = data1.(yVar);
+    mask1 = (data1.FZ>=fzMin & data1.FZ<=fzMax) & (data1.P>=pMin & data1.P<=pMax) & ...
+            (data1.IA>=iaMin & data1.IA<=iaMax);
+    xF1 = X1(mask1); yF1 = Y1(mask1);
+
+    % Dataset 2
+    X2 = data2.(xVar); Y2 = data2.(yVar);
+    mask2 = (data2.FZ>=fzMin & data2.FZ<=fzMax) & (data2.P>=pMin & data2.P<=pMax) & ...
+            (data2.IA>=iaMin & data2.IA<=iaMax);
+    xF2 = X2(mask2);
+    yF2 = Y2(mask2) - offset2;
+
+    % Combine
+    xF = [xF1; xF2];
+    yF = [yF1; yF2];
+
     [xF, idx] = sort(xF); yF = yF(idx);
     % PAC2002 fit
     mfFun = @(p,x) p(3).*sin(p(2).*atan(p(1).*x - p(4).*(p(1).*x - atan(p(1).*x))));


### PR DESCRIPTION
## Summary
- extend `plotTTCData_fit.m` to load two MAT files
- overlay both datasets in the interactive plot
- update curve fitting to use the combined data
- comment out temperature-dependent coloring
- offset the second dataset downward by 63

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874e65a671c83219ad606a90ef8bd47